### PR TITLE
Normalize vector length if diagonal

### DIFF
--- a/tdt4240/tdt4240/InputDevice.cs
+++ b/tdt4240/tdt4240/InputDevice.cs
@@ -101,6 +101,11 @@ namespace tdt4240
                 if(state.IsKeyDown(Keys.D))
                         vec.X += 1;
 
+                if (vec.Length() > 1)
+                {
+                    vec *= 1 / vec.Length();
+                }
+
                 return vec;
             }
         }


### PR DESCRIPTION
Because it makes sense to move with the same velocity no matter the direction. The analog stick that we're trying to emulate behaves that way, AFAIK.
